### PR TITLE
Use locks for mutable state within JobManager

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,4 +13,4 @@ notifications:
       - "Build Details: %{build_url}"
 
 script:
-  - go test
+  - go test -timeout 4s -race

--- a/README.md
+++ b/README.md
@@ -18,9 +18,7 @@ import "github.com/blendlabs/go-chronometer"
 
 	chronometer.Default().RunTask(chronometer.NewTask(func(ct *chronometer.CancellationToken) error {
 		... //long winded process here
-		if ct.ShouldCancel {
-			return ct.Cancel()
-		}
+		ct.CheckCancellation()
 	}))
 ```
 

--- a/atomic_flag.go
+++ b/atomic_flag.go
@@ -1,0 +1,23 @@
+package chronometer
+
+import "sync"
+
+// AtomicFlag is a boolean value that is syncronized.
+type AtomicFlag struct {
+	lock  sync.RWMutex
+	value bool
+}
+
+// Set the flag value.
+func (af *AtomicFlag) Set(value bool) {
+	af.lock.Lock()
+	defer af.lock.Unlock()
+	af.value = value
+}
+
+// Get the flag value.
+func (af *AtomicFlag) Get() bool {
+	af.lock.RLock()
+	defer af.lock.RUnlock()
+	return af.value
+}

--- a/atomic_flag.go
+++ b/atomic_flag.go
@@ -21,3 +21,31 @@ func (af *AtomicFlag) Get() bool {
 	defer af.lock.RUnlock()
 	return af.value
 }
+
+// AtomicCounter is a counter that you should use
+// instead of atomic.AddInt32(...)
+type AtomicCounter struct {
+	lock  sync.RWMutex
+	value int
+}
+
+// Increment the value.
+func (ac *AtomicCounter) Increment() {
+	ac.lock.Lock()
+	defer ac.lock.Unlock()
+	ac.value++
+}
+
+// Decrement the value.
+func (ac *AtomicCounter) Decrement() {
+	ac.lock.Lock()
+	defer ac.lock.Unlock()
+	ac.value--
+}
+
+// Get returns the counter value.
+func (ac *AtomicCounter) Get() int {
+	ac.lock.RLock()
+	defer ac.lock.RUnlock()
+	return ac.value
+}

--- a/cancellation_token.go
+++ b/cancellation_token.go
@@ -46,5 +46,7 @@ func (ct *CancellationToken) didCancel() bool {
 func (ct *CancellationToken) CheckCancellation() {
 	ct.shouldCancelLock.RLock()
 	defer ct.shouldCancelLock.RUnlock()
-	panic(NewCancellationPanic())
+	if ct.shouldCancel {
+		panic(NewCancellationPanic())
+	}
 }

--- a/job_manager.go
+++ b/job_manager.go
@@ -565,6 +565,19 @@ func (jm *JobManager) killHangingJobsInner() {
 
 // Status returns the status metadata for a JobManager
 func (jm *JobManager) Status() []TaskStatus {
+
+	jm.loadedJobsLock.RLock()
+	defer jm.loadedJobsLock.RUnlock()
+
+	jm.runningTaskStartTimesLock.RLock()
+	defer jm.runningTaskStartTimesLock.RUnlock()
+
+	jm.disabledJobsLock.RLock()
+	defer jm.disabledJobsLock.RUnlock()
+
+	jm.runningTasksLock.RLock()
+	defer jm.runningTasksLock.RUnlock()
+
 	var statuses []TaskStatus
 	now := time.Now().UTC()
 	for jobName, job := range jm.loadedJobs {
@@ -607,6 +620,12 @@ func (jm *JobManager) Status() []TaskStatus {
 
 // TaskStatus returns the status metadata for a given task.
 func (jm *JobManager) TaskStatus(taskName string) *TaskStatus {
+	jm.runningTaskStartTimesLock.RLock()
+	defer jm.runningTaskStartTimesLock.RUnlock()
+
+	jm.runningTasksLock.RLock()
+	defer jm.runningTasksLock.RUnlock()
+
 	if task, isRunning := jm.runningTasks[taskName]; isRunning {
 		now := time.Now().UTC()
 		status := TaskStatus{

--- a/job_manager.go
+++ b/job_manager.go
@@ -30,20 +30,17 @@ const (
 
 // NewJobManager returns a new instance of JobManager.
 func NewJobManager() *JobManager {
-	jm := JobManager{}
+	jm := JobManager{
+		loadedJobs:            map[string]Job{},
+		runningTasks:          map[string]Task{},
+		schedules:             map[string]Schedule{},
+		cancellationTokens:    map[string]*CancellationToken{},
+		runningTaskStartTimes: map[string]time.Time{},
+		lastRunTimes:          map[string]time.Time{},
+		nextRunTimes:          map[string]*time.Time{},
+		disabledJobs:          collections.StringSet{},
+	}
 
-	jm.LoadedJobs = map[string]Job{}
-	jm.RunningTasks = map[string]Task{}
-	jm.Schedules = map[string]Schedule{}
-
-	jm.CancellationTokens = map[string]*CancellationToken{}
-	jm.RunningTaskStartTimes = map[string]time.Time{}
-	jm.LastRunTimes = map[string]time.Time{}
-	jm.NextRunTimes = map[string]time.Time{}
-
-	jm.DisabledJobs = collections.StringSet{}
-
-	jm.metaLock = &sync.Mutex{}
 	return &jm
 }
 
@@ -65,78 +62,305 @@ func Default() *JobManager {
 
 // JobManager is the main orchestration and job management object.
 type JobManager struct {
-	LoadedJobs   map[string]Job
-	DisabledJobs collections.StringSet
-	RunningTasks map[string]Task
-	Schedules    map[string]Schedule
+	loadedJobsLock sync.RWMutex
+	loadedJobs     map[string]Job
 
-	CancellationTokens    map[string]*CancellationToken
-	RunningTaskStartTimes map[string]time.Time
-	LastRunTimes          map[string]time.Time
-	NextRunTimes          map[string]time.Time
+	disabledJobsLock sync.RWMutex
+	disabledJobs     collections.StringSet
+
+	runningTasksLock sync.RWMutex
+	runningTasks     map[string]Task
+
+	schedulesLock sync.RWMutex
+	schedules     map[string]Schedule
+
+	cancellationTokensLock sync.RWMutex
+	cancellationTokens     map[string]*CancellationToken
+
+	runningTaskStartTimesLock sync.RWMutex
+	runningTaskStartTimes     map[string]time.Time
+
+	lastRunTimesLock sync.RWMutex
+	lastRunTimes     map[string]time.Time
+
+	nextRunTimesLock sync.RWMutex
+	nextRunTimes     map[string]*time.Time
 
 	isRunning      bool
 	schedulerToken *CancellationToken
-	metaLock       *sync.Mutex
 }
+
+// --------------------------------------------------------------------------------
+// Atomic Methods
+// --------------------------------------------------------------------------------
+
+// GetCancellationToken gets jm.cancellationTokens
+func (jm *JobManager) GetCancellationToken(jobName string) *CancellationToken {
+	jm.cancellationTokensLock.Lock()
+	defer jm.cancellationTokensLock.Unlock()
+
+	return jm.cancellationTokens[jobName]
+}
+
+// SetCancellationToken sets jm.cancellationTokens
+func (jm *JobManager) SetCancellationToken(jobName string, t *CancellationToken) {
+	jm.cancellationTokensLock.Lock()
+	defer jm.cancellationTokensLock.Unlock()
+
+	jm.cancellationTokens[jobName] = t
+}
+
+// DeleteCancellationToken deletes jm.cancellationTokens
+func (jm *JobManager) DeleteCancellationToken(jobName string) {
+	jm.cancellationTokensLock.Lock()
+	defer jm.cancellationTokensLock.Unlock()
+
+	delete(jm.cancellationTokens, jobName)
+}
+
+// SetDisabledJob sets jm.disabledJobs
+func (jm *JobManager) SetDisabledJob(jobName string) {
+	jm.disabledJobsLock.Lock()
+	defer jm.disabledJobsLock.Unlock()
+
+	jm.disabledJobs.Add(jobName)
+}
+
+// DeleteDisabledJob deletes jm.disabledJobs
+func (jm *JobManager) DeleteDisabledJob(jobName string) {
+	jm.disabledJobsLock.Lock()
+	defer jm.disabledJobsLock.Unlock()
+
+	jm.disabledJobs.Remove(jobName)
+}
+
+// GetNextRunTime gets jm.nextRunTimes
+func (jm *JobManager) GetNextRunTime(jobName string) *time.Time {
+	jm.nextRunTimesLock.Lock()
+	defer jm.nextRunTimesLock.Unlock()
+
+	return jm.nextRunTimes[jobName]
+}
+
+// SetNextRunTime sets jm.nextRunTimes
+func (jm *JobManager) SetNextRunTime(jobName string, t *time.Time) {
+	jm.nextRunTimesLock.Lock()
+	defer jm.nextRunTimesLock.Unlock()
+
+	jm.nextRunTimes[jobName] = t
+}
+
+// DeleteNextRunTime deletes jm.nextRunTimes
+func (jm *JobManager) DeleteNextRunTime(jobName string) {
+	jm.nextRunTimesLock.Lock()
+	defer jm.nextRunTimesLock.Unlock()
+
+	delete(jm.nextRunTimes, jobName)
+}
+
+// GetLastRunTime gets jm.LastRunTimes
+func (jm *JobManager) GetLastRunTime(taskName string) time.Time {
+	jm.lastRunTimesLock.RLock()
+	defer jm.lastRunTimesLock.RUnlock()
+
+	return jm.lastRunTimes[taskName]
+}
+
+// SetLastRunTime sets jm.LastRunTimes
+func (jm *JobManager) SetLastRunTime(taskName string, t time.Time) {
+	jm.lastRunTimesLock.Lock()
+	defer jm.lastRunTimesLock.Unlock()
+
+	jm.lastRunTimes[taskName] = t
+}
+
+// DeleteLastRunTime deletes jm.LastRunTimes
+func (jm *JobManager) DeleteLastRunTime(taskName string) {
+	jm.lastRunTimesLock.Lock()
+	defer jm.lastRunTimesLock.Unlock()
+
+	delete(jm.lastRunTimes, taskName)
+}
+
+// GetLoadedJob gets a job
+func (jm *JobManager) GetLoadedJob(jobName string) Job {
+	jm.loadedJobsLock.RLock()
+	defer jm.loadedJobsLock.RUnlock()
+	return jm.loadedJobs[jobName]
+}
+
+// SetLoadedJob sets jm.loadedJobs
+func (jm *JobManager) SetLoadedJob(jobName string, j Job) {
+	jm.loadedJobsLock.Lock()
+	defer jm.loadedJobsLock.Unlock()
+
+	jm.loadedJobs[jobName] = j
+}
+
+// DeleteLoadedJob deletes jm.loadedJobs
+func (jm *JobManager) DeleteLoadedJob(jobName string) {
+	jm.loadedJobsLock.Lock()
+	defer jm.loadedJobsLock.Unlock()
+
+	delete(jm.loadedJobs, jobName)
+}
+
+// GetRunningTask gets jm.runningTasks
+func (jm *JobManager) GetRunningTask(taskName string) Task {
+	jm.runningTasksLock.RLock()
+	defer jm.runningTasksLock.RUnlock()
+
+	return jm.runningTasks[taskName]
+}
+
+// SetRunningTask sets jm.runningTasks
+func (jm *JobManager) SetRunningTask(taskName string, t Task) {
+	jm.runningTasksLock.Lock()
+	defer jm.runningTasksLock.Unlock()
+
+	jm.runningTasks[taskName] = t
+}
+
+// DeleteRunningTask deletes jm.runningTasks
+func (jm *JobManager) DeleteRunningTask(taskName string) {
+	jm.runningTasksLock.Lock()
+	defer jm.runningTasksLock.Unlock()
+
+	delete(jm.runningTasks, taskName)
+}
+
+// GetRunningTaskStartTime gets jm.runningTaskStartTimess
+func (jm *JobManager) GetRunningTaskStartTime(taskName string) time.Time {
+	jm.runningTaskStartTimesLock.RLock()
+	defer jm.runningTaskStartTimesLock.RUnlock()
+
+	return jm.runningTaskStartTimes[taskName]
+}
+
+// SetRunningTaskStartTime sets jm.runningTaskStartTimess
+func (jm *JobManager) SetRunningTaskStartTime(taskName string, t time.Time) {
+	jm.runningTaskStartTimesLock.Lock()
+	defer jm.runningTaskStartTimesLock.Unlock()
+
+	jm.runningTaskStartTimes[taskName] = t
+}
+
+// DeleteRunningTaskStartTime deletes jm.runningTaskStartTimes
+func (jm *JobManager) DeleteRunningTaskStartTime(taskName string) {
+	jm.runningTaskStartTimesLock.Lock()
+	defer jm.runningTaskStartTimesLock.Unlock()
+
+	delete(jm.runningTaskStartTimes, taskName)
+}
+
+// GetSchedule gets jm.schedules
+func (jm *JobManager) GetSchedule(jobName string) Schedule {
+	jm.schedulesLock.RLock()
+	defer jm.schedulesLock.RUnlock()
+
+	return jm.schedules[jobName]
+}
+
+// SetSchedule sets jm.schedules
+func (jm *JobManager) SetSchedule(jobName string, schedule Schedule) {
+	jm.schedulesLock.Lock()
+	defer jm.schedulesLock.Unlock()
+
+	jm.schedules[jobName] = schedule
+}
+
+// DeleteSchedule deltes jm.schedules
+func (jm *JobManager) DeleteSchedule(jobName string) {
+	jm.schedulesLock.Lock()
+	defer jm.schedulesLock.Unlock()
+
+	delete(jm.schedules, jobName)
+}
+
+// HasJob returns if a jobName is loaded or not.
+func (jm *JobManager) HasJob(jobName string) bool {
+	jm.loadedJobsLock.RLock()
+	defer jm.loadedJobsLock.RUnlock()
+	_, hasJob := jm.loadedJobs[jobName]
+	return hasJob
+}
+
+// IsDisabled returns if a job is disabled.
+func (jm *JobManager) IsDisabled(jobName string) bool {
+	jm.disabledJobsLock.RLock()
+	defer jm.disabledJobsLock.RUnlock()
+
+	return jm.disabledJobs.Contains(jobName)
+}
+
+// IsRunning returns if a task is currently running.
+func (jm *JobManager) IsRunning(taskName string) bool {
+	jm.runningTasksLock.RLock()
+	defer jm.runningTasksLock.RUnlock()
+
+	_, isRunning := jm.runningTasks[taskName]
+	return isRunning
+}
+
+// --------------------------------------------------------------------------------
+// END Atomic methods
+// --------------------------------------------------------------------------------
 
 // LoadJob adds a job to the manager.
 func (jm *JobManager) LoadJob(j Job) error {
-	if _, hasJob := jm.LoadedJobs[j.Name()]; hasJob {
+	jobName := j.Name()
+
+	if jm.HasJob(jobName) {
 		return exception.Newf("Job name `%s` already loaded.", j.Name())
 	}
 
-	jm.metaLock.Lock()
-	defer jm.metaLock.Unlock()
+	jm.SetLoadedJob(jobName, j)
 
-	jobName := j.Name()
 	jobSchedule := j.Schedule()
-
-	jm.LoadedJobs[jobName] = j
-	jm.Schedules[jobName] = jobSchedule
-	jm.NextRunTimes[jobName] = jobSchedule.GetNextRunTime(nil)
+	jm.SetSchedule(jobName, jobSchedule)
+	jm.SetNextRunTime(jobName, jobSchedule.GetNextRunTime(nil))
 
 	return nil
 }
 
 // DisableJob stops a job from running but does not unload it.
 func (jm *JobManager) DisableJob(jobName string) error {
-	if _, hasJob := jm.LoadedJobs[jobName]; !hasJob {
+	if !jm.HasJob(jobName) {
 		return exception.Newf("Job name `%s` isn't loaded.", jobName)
 	}
 
-	jm.metaLock.Lock()
-	defer jm.metaLock.Unlock()
-
-	jm.DisabledJobs.Add(jobName)
-	delete(jm.NextRunTimes, jobName)
+	jm.SetDisabledJob(jobName)
+	jm.DeleteNextRunTime(jobName)
 	return nil
 }
 
 // EnableJob enables a job that has been disabled.
 func (jm *JobManager) EnableJob(jobName string) error {
-	jm.metaLock.Lock()
-	defer jm.metaLock.Unlock()
-
-	jm.DisabledJobs.Remove(jobName)
-
-	job, hasJob := jm.LoadedJobs[jobName]
-	if !hasJob {
+	if !jm.HasJob(jobName) {
 		return exception.Newf("Job name `%s` isn't loaded.", jobName)
 	}
+
+	jm.DeleteDisabledJob(jobName)
+
+	job := jm.loadedJobs[jobName]
 	jobSchedule := job.Schedule()
-	jm.NextRunTimes[jobName] = jobSchedule.GetNextRunTime(nil)
+	jm.SetNextRunTime(jobName, jobSchedule.GetNextRunTime(nil))
+
 	return nil
 }
 
 // RunJob runs a job by jobName on demand.
 func (jm *JobManager) RunJob(jobName string) error {
-	if job, hasJob := jm.LoadedJobs[jobName]; hasJob {
-		if !jm.DisabledJobs.Contains(jobName) {
+	jm.loadedJobsLock.RLock()
+	defer jm.loadedJobsLock.RUnlock()
+
+	jm.disabledJobsLock.RLock()
+	defer jm.disabledJobsLock.RUnlock()
+
+	if job, hasJob := jm.loadedJobs[jobName]; hasJob {
+		if !jm.disabledJobs.Contains(jobName) {
 			now := time.Now().UTC()
-
-			jm.LastRunTimes[jobName] = now
-
+			jm.SetLastRunTime(jobName, now)
 			return jm.RunTask(job)
 		}
 		return nil
@@ -146,10 +370,11 @@ func (jm *JobManager) RunJob(jobName string) error {
 
 // RunAllJobs runs every job that has been loaded in the JobManager at once.
 func (jm *JobManager) RunAllJobs() error {
-	now := time.Now().UTC()
-	for jobName, job := range jm.LoadedJobs {
-		if !jm.DisabledJobs.Contains(jobName) {
-			jm.LastRunTimes[jobName] = now
+	jm.loadedJobsLock.RLock()
+	defer jm.loadedJobsLock.RUnlock()
+
+	for jobName, job := range jm.loadedJobs {
+		if !jm.IsDisabled(jobName) {
 			jobErr := jm.RunTask(job)
 			if jobErr != nil {
 				return jobErr
@@ -161,15 +386,14 @@ func (jm *JobManager) RunAllJobs() error {
 
 // RunTask runs a task on demand.
 func (jm *JobManager) RunTask(t Task) error {
-	jm.metaLock.Lock()
-	defer jm.metaLock.Unlock()
-
 	taskName := t.Name()
 	ct := NewCancellationToken()
+	now := time.Now().UTC()
 
-	jm.RunningTasks[taskName] = t
-	jm.CancellationTokens[taskName] = ct
-	jm.RunningTaskStartTimes[taskName] = time.Now().UTC()
+	jm.SetRunningTask(taskName, t)
+	jm.SetCancellationToken(taskName, ct)
+	jm.SetRunningTaskStartTime(taskName, now)
+	jm.SetLastRunTime(taskName, now)
 
 	didFinish := false
 	taskFinished := make(chan bool, 1)
@@ -242,26 +466,23 @@ func (jm *JobManager) taskCancellationCheck(t Task, ct *CancellationToken) bool 
 }
 
 func (jm *JobManager) cleanupTask(taskName string) {
-	jm.metaLock.Lock()
-	defer jm.metaLock.Unlock()
-
-	delete(jm.RunningTaskStartTimes, taskName)
-	delete(jm.RunningTasks, taskName)
-	delete(jm.CancellationTokens, taskName)
+	jm.DeleteRunningTaskStartTime(taskName)
+	jm.DeleteRunningTask(taskName)
+	jm.DeleteCancellationToken(taskName)
 }
 
 // CancelTask cancels (sends the cancellation signal) to a running task.
 func (jm *JobManager) CancelTask(taskName string) error {
-	if task, hasTask := jm.RunningTasks[taskName]; hasTask {
-		if token, hasCancellationToken := jm.CancellationTokens[taskName]; hasCancellationToken {
-			jm.cleanupTask(taskName)
-			if receiver, isReceiver := task.(OnCancellationReceiver); isReceiver {
-				receiver.OnCancellation()
-			}
-			token.signalCancellation()
-		} else {
-			return exception.Newf("Cancellation token for job name `%s` not found.", taskName)
+	jm.runningTasksLock.RLock()
+	defer jm.runningTasksLock.RUnlock()
+
+	if task, hasTask := jm.runningTasks[taskName]; hasTask {
+		token := jm.GetCancellationToken(taskName)
+		jm.cleanupTask(taskName)
+		if receiver, isReceiver := task.(OnCancellationReceiver); isReceiver {
+			receiver.OnCancellation()
 		}
+		token.signalCancellation()
 	}
 	return exception.Newf("Job name `%s` not found.", taskName)
 }
@@ -270,8 +491,10 @@ func (jm *JobManager) CancelTask(taskName string) error {
 func (jm *JobManager) Start() {
 	ct := NewCancellationToken()
 	jm.schedulerToken = ct
+
 	go jm.runDueJobs(ct)
 	go jm.killHangingJobs(ct)
+
 	jm.isRunning = true
 }
 
@@ -286,42 +509,57 @@ func (jm *JobManager) Stop() {
 
 func (jm *JobManager) runDueJobs(ct *CancellationToken) {
 	for !ct.ShouldCancel() {
-		now := time.Now().UTC()
+		jm.runDueJobsInner()
+		time.Sleep(HeartbeatInterval)
+	}
+}
 
-		for jobName, nextRunTime := range jm.NextRunTimes {
-			if !jm.DisabledJobs.Contains(jobName) {
+func (jm *JobManager) runDueJobsInner() {
+	jm.nextRunTimesLock.Lock()
+	defer jm.nextRunTimesLock.Unlock()
+
+	now := time.Now().UTC()
+
+	for jobName, nextRunTime := range jm.nextRunTimes {
+		if nextRunTime != nil {
+			if !jm.IsDisabled(jobName) {
 				if nextRunTime.Before(now) {
-					jm.metaLock.Lock()
-					jm.NextRunTimes[jobName] = jm.Schedules[jobName].GetNextRunTime(&now)
-					jm.metaLock.Unlock()
-
+					jm.nextRunTimes[jobName] = jm.GetSchedule(jobName).GetNextRunTime(&now)
 					jm.RunJob(jobName)
 				}
 			}
 		}
-
-		time.Sleep(HeartbeatInterval)
 	}
 }
 
 func (jm *JobManager) killHangingJobs(ct *CancellationToken) {
 	for !ct.ShouldCancel() {
-		now := time.Now().UTC()
+		jm.killHangingJobsInner()
+		time.Sleep(HeartbeatInterval)
+	}
+}
 
-		for taskName, startedTime := range jm.RunningTaskStartTimes {
-			if task, hasTask := jm.RunningTasks[taskName]; hasTask {
-				if timeoutProvider, isTimeoutProvder := task.(TimeoutProvider); isTimeoutProvder {
-					timeout := timeoutProvider.Timeout()
-					if now.Sub(startedTime) >= timeout {
-						jm.CancelTask(taskName)
-						if receiver, isReceiver := task.(OnCompleteReceiver); isReceiver {
-							receiver.OnComplete(exception.New("Timeout Reached."))
-						}
+func (jm *JobManager) killHangingJobsInner() {
+	jm.runningTaskStartTimesLock.RLock()
+	defer jm.runningTaskStartTimesLock.RUnlock()
+
+	jm.runningTasksLock.RLock()
+	defer jm.runningTasksLock.RUnlock()
+
+	now := time.Now().UTC()
+
+	for taskName, startedTime := range jm.runningTaskStartTimes {
+		if task, hasTask := jm.runningTasks[taskName]; hasTask {
+			if timeoutProvider, isTimeoutProvder := task.(TimeoutProvider); isTimeoutProvder {
+				timeout := timeoutProvider.Timeout()
+				if now.Sub(startedTime) >= timeout {
+					jm.CancelTask(taskName)
+					if receiver, isReceiver := task.(OnCompleteReceiver); isReceiver {
+						receiver.OnComplete(exception.New("Timeout Reached."))
 					}
 				}
 			}
 		}
-		time.Sleep(HeartbeatInterval)
 	}
 }
 
@@ -329,14 +567,14 @@ func (jm *JobManager) killHangingJobs(ct *CancellationToken) {
 func (jm *JobManager) Status() []TaskStatus {
 	var statuses []TaskStatus
 	now := time.Now().UTC()
-	for jobName, job := range jm.LoadedJobs {
+	for jobName, job := range jm.loadedJobs {
 		status := TaskStatus{}
 		status.Name = jobName
 
-		if runningSince, isRunning := jm.RunningTaskStartTimes[jobName]; isRunning {
+		if runningSince, isRunning := jm.runningTaskStartTimes[jobName]; isRunning {
 			status.State = StateRunning
 			status.RunningFor = fmt.Sprintf("%v", now.Sub(runningSince))
-		} else if jm.DisabledJobs.Contains(jobName) {
+		} else if jm.disabledJobs.Contains(jobName) {
 			status.State = StateDisabled
 		} else {
 			status.State = StateEnabled
@@ -349,13 +587,13 @@ func (jm *JobManager) Status() []TaskStatus {
 		statuses = append(statuses, status)
 	}
 
-	for taskName, task := range jm.RunningTasks {
-		if _, isJob := jm.LoadedJobs[taskName]; !isJob {
+	for taskName, task := range jm.runningTasks {
+		if _, isJob := jm.loadedJobs[taskName]; !isJob {
 			status := TaskStatus{
 				Name:  taskName,
 				State: StateRunning,
 			}
-			if runningSince, isRunning := jm.RunningTaskStartTimes[taskName]; isRunning {
+			if runningSince, isRunning := jm.runningTaskStartTimes[taskName]; isRunning {
 				status.RunningFor = fmt.Sprintf("%v", now.Sub(runningSince))
 			}
 			if statusProvider, isStatusProvider := task.(StatusProvider); isStatusProvider {
@@ -369,13 +607,13 @@ func (jm *JobManager) Status() []TaskStatus {
 
 // TaskStatus returns the status metadata for a given task.
 func (jm *JobManager) TaskStatus(taskName string) *TaskStatus {
-	if task, isRunning := jm.RunningTasks[taskName]; isRunning {
+	if task, isRunning := jm.runningTasks[taskName]; isRunning {
 		now := time.Now().UTC()
 		status := TaskStatus{
 			Name:  taskName,
 			State: StateRunning,
 		}
-		if runningSince, isRunning := jm.RunningTaskStartTimes[taskName]; isRunning {
+		if runningSince, isRunning := jm.runningTaskStartTimes[taskName]; isRunning {
 			status.RunningFor = fmt.Sprintf("%v", now.Sub(runningSince))
 		}
 		if statusProvider, isStatusProvider := task.(StatusProvider); isStatusProvider {

--- a/job_manager.go
+++ b/job_manager.go
@@ -344,8 +344,7 @@ func (jm *JobManager) EnableJob(jobName string) error {
 	}
 
 	jm.DeleteDisabledJob(jobName)
-
-	job := jm.loadedJobs[jobName]
+	job := jm.GetLoadedJob(jobName)
 	jobSchedule := job.Schedule()
 	jm.SetNextRunTime(jobName, jobSchedule.GetNextRunTime(nil))
 

--- a/job_manager.go
+++ b/job_manager.go
@@ -410,11 +410,11 @@ func (jm *JobManager) RunTask(t Task) error {
 
 		defer func() {
 			if r := recover(); r != nil {
+				wg.Done()
 				if _, isCancellation := r.(CancellationPanic); !isCancellation {
 					panic(r)
 				}
 			}
-			wg.Done()
 		}()
 
 		didFinish := new(AtomicFlag)

--- a/job_manager.go
+++ b/job_manager.go
@@ -558,6 +558,10 @@ func (jm *JobManager) killHangingJobsInner() {
 }
 
 // killHangingJob cancels (sends the cancellation signal) to a running task that has exceeded its timeout.
+// it assumes that the following locks are held:
+// - runningTasksLock
+// - runningTaskStartTimesLock
+// - cancellationTokensLock
 func (jm *JobManager) killHangingJob(taskName string) error {
 	if task, hasTask := jm.runningTasks[taskName]; hasTask {
 		if token, hasToken := jm.cancellationTokens[taskName]; hasToken {

--- a/job_manager_test.go
+++ b/job_manager_test.go
@@ -220,6 +220,7 @@ func TestRunTaskAndCancelWithTimeout(t *testing.T) {
 	start := time.Now().UTC()
 	didRun := new(AtomicFlag)
 	didCancel := new(AtomicFlag)
+	cancelCount := new(AtomicCounter)
 	jm.LoadJob(&testJobWithTimeout{
 		RunAt:           start,
 		TimeoutDuration: 100 * time.Millisecond,
@@ -233,6 +234,7 @@ func TestRunTaskAndCancelWithTimeout(t *testing.T) {
 			return nil
 		},
 		CancellationDelegate: func() {
+			cancelCount.Increment()
 			didCancel.Set(true)
 		},
 	})
@@ -247,6 +249,8 @@ func TestRunTaskAndCancelWithTimeout(t *testing.T) {
 
 	a.True(didRun.Get())
 	a.True(didCancel.Get())
+	a.Equal(1, cancelCount.Get())
+
 	// elapsed should be less than the timeout + (2 heartbeat intervals)
 	a.True(elapsed < (100+(HangingHeartbeatInterval*2))*time.Millisecond, fmt.Sprintf("%v", elapsed))
 }

--- a/job_manager_test.go
+++ b/job_manager_test.go
@@ -188,3 +188,25 @@ func TestDisableJob(t *testing.T) {
 
 	a.True(jm.disabledJobs.Contains("testJob"))
 }
+
+type testJobWithTimeout struct {
+	RunAt           time.Time
+	TimeoutDuration time.Duration
+	RunDelegate     func(ct *CancellationToken) error
+}
+
+func (tj *testJobWithTimeout) Name() string {
+	return "testJobWithTimeout"
+}
+
+func (tj *testJobWithTimeout) Timeout() time.Duration {
+	return tj.TimeoutDuration
+}
+
+func (tj *testJobWithTimeout) Schedule() Schedule {
+	return testJobSchedule{RunAt: tj.RunAt}
+}
+
+func (tj *testJobWithTimeout) Execute(ct *CancellationToken) error {
+	return tj.RunDelegate(ct)
+}

--- a/job_manager_test.go
+++ b/job_manager_test.go
@@ -314,7 +314,7 @@ func TestRunJobByScheduleRapid(t *testing.T) {
 	a := assert.New(t)
 
 	runEvery := 50 * time.Millisecond
-	runFor := 250 * time.Millisecond
+	runFor := 1000 * time.Millisecond
 
 	var runCount int64
 	jm := NewJobManager()
@@ -334,5 +334,7 @@ func TestRunJobByScheduleRapid(t *testing.T) {
 		time.Sleep(waitFor)
 	}
 
-	a.True(runCount > int64(runFor)/int64(HeartbeatInterval))
+	expected := int64(runFor) / int64(HeartbeatInterval)
+
+	a.True(runCount >= expected, fmt.Sprintf("%d vs. %d\n", runCount, expected))
 }

--- a/load_test/main.go
+++ b/load_test/main.go
@@ -3,18 +3,44 @@ package main
 import (
 	"fmt"
 	"math/rand"
+	"os"
 	"time"
 
 	"github.com/blendlabs/go-chronometer"
 )
 
+const (
+	// N is the number of jobs to load.
+	N = 1
+
+	// Q is the total simulation time.
+	Q = 30 * time.Second
+
+	// JobRunEvery is the job interval.
+	JobRunEvery = 5 * time.Second
+
+	// JobTimeout is the timeout for the jobs.
+	JobTimeout = 3 * time.Second
+
+	// JobShortRunTime is the short run time.
+	JobShortRunTime = 2 * time.Second
+
+	// JobLongRunTime is the long run time (will induce a timeout.)
+	JobLongRunTime = 8 * time.Second
+)
+
+var startedCount = new(chronometer.AtomicCounter)
+var completeCount = new(chronometer.AtomicCounter)
+var timeoutCount = new(chronometer.AtomicCounter)
+
 type loadTestJob struct {
 	id      int
 	running bool
+	started time.Time
 }
 
 func (j *loadTestJob) Timeout() time.Duration {
-	return 2 * time.Second
+	return JobTimeout
 }
 
 func (j *loadTestJob) Name() string {
@@ -22,39 +48,70 @@ func (j *loadTestJob) Name() string {
 }
 
 func (j *loadTestJob) Execute(ct *chronometer.CancellationToken) error {
+	j.started = time.Now()
+	startedCount.Increment()
 	j.running = true
-	if rand.Int()%2 == 1 {
-		time.Sleep(2000 * time.Millisecond)
+	if rand.Float64() < 0.5 { // 50% split between short vs. long.
+		time.Sleep(JobShortRunTime)
 	} else {
-		time.Sleep(8000 * time.Millisecond)
+		time.Sleep(JobLongRunTime)
 	}
 	j.running = false
-	fmt.Printf("%s ran\n", j.Name())
+	completeCount.Increment()
+	fmt.Printf("%v - Complete @ %v\n", time.Now().String(), time.Now().Sub(j.started))
 	return nil
 }
 
 func (j *loadTestJob) OnCancellation() {
+	fmt.Printf("%v - Timeout @ %v\n", time.Now().String(), time.Now().Sub(j.started))
+	timeoutCount.Increment()
 	j.running = false
 }
 
 func (j *loadTestJob) Status() string {
 	if j.running {
-		return "Request in progress"
+		return "Request in progress."
 	}
 	return "Request idle."
 }
 
 func (j *loadTestJob) Schedule() chronometer.Schedule {
-	return chronometer.Every(10 * time.Second)
+	return chronometer.Every(JobRunEvery)
 }
 
 func main() {
-	for x := 1; x < 1000; x++ {
-		chronometer.Default().LoadJob(&loadTestJob{id: x})
-		//fmt.Printf("loaded job %d\n", x)
+	defer func() {
+		chronometer.Default().Stop()
+	}()
+
+	if JobLongRunTime < JobTimeout {
+		fmt.Printf("Long Run Time: %v is less than the Time Out: %v\n", JobTimeout, JobLongRunTime)
+		fmt.Printf("This will cause the Completed vs. Timed Out counts to be wrong.\n")
+		os.Exit(1)
 	}
-	fmt.Printf("Loaded 1000 Job Instances.\n")
+
+	for x := 0; x < N; x++ {
+		chronometer.Default().LoadJob(&loadTestJob{id: x})
+	}
+	fmt.Printf("Loaded %d Job Instances.\n\n", N)
 	chronometer.Default().Start()
 
-	time.Sleep(30 * time.Second)
+	time.Sleep(Q)
+
+	//given 30 seconds total
+	// and running every 5 seconds
+	// we expect each job to run 5 times (ish)
+
+	expectedStarted := N * ((int64(Q) / int64(JobRunEvery)) - 1)
+	expectedCompleted := expectedStarted >> 1
+	expectedTimedOut := expectedStarted >> 1
+
+	fmt.Printf("\nExpected Jobs Started:   %d\n", expectedStarted)
+	fmt.Printf("Actual Jobs Started:     %d\n\n", startedCount.Get())
+
+	fmt.Printf("Expected Jobs Completed: %d\n", expectedCompleted)
+	fmt.Printf("Actual Jobs Completed:   %d\n\n", completeCount.Get())
+
+	fmt.Printf("Expected Jobs Timed Out: %d\n", expectedTimedOut)
+	fmt.Printf("Actual Jobs Timed Out:   %d\n", timeoutCount.Get())
 }

--- a/load_test/main.go
+++ b/load_test/main.go
@@ -58,12 +58,12 @@ func (j *loadTestJob) Execute(ct *chronometer.CancellationToken) error {
 	}
 	j.running = false
 	completeCount.Increment()
-	fmt.Printf("%v - Complete @ %v\n", time.Now().String(), time.Now().Sub(j.started))
+	fmt.Printf("%v - Complete @ %v\n", time.Now().Format(time.RFC3339), time.Now().Sub(j.started))
 	return nil
 }
 
 func (j *loadTestJob) OnCancellation() {
-	fmt.Printf("%v - Timeout @ %v\n", time.Now().String(), time.Now().Sub(j.started))
+	fmt.Printf("%v - Timeout @ %v\n", time.Now().Format(time.RFC3339), time.Now().Sub(j.started))
 	timeoutCount.Increment()
 	j.running = false
 }

--- a/load_test/main.go
+++ b/load_test/main.go
@@ -40,9 +40,8 @@ func (j *loadTestJob) OnCancellation() {
 func (j *loadTestJob) Status() string {
 	if j.running {
 		return "Request in progress"
-	} else {
-		return "Request idle."
 	}
+	return "Request idle."
 }
 
 func (j *loadTestJob) Schedule() chronometer.Schedule {
@@ -52,8 +51,9 @@ func (j *loadTestJob) Schedule() chronometer.Schedule {
 func main() {
 	for x := 1; x < 1000; x++ {
 		chronometer.Default().LoadJob(&loadTestJob{id: x})
-		fmt.Printf("loaded job %d\n", x)
+		//fmt.Printf("loaded job %d\n", x)
 	}
+	fmt.Printf("Loaded 1000 Job Instances.\n")
 	chronometer.Default().Start()
 
 	time.Sleep(30 * time.Second)


### PR DESCRIPTION
This PR creates locks for each map we write to within JobManager. Deadlocks inbound. 