### PR TITLE
Use setNextRunTime to ensure proper locking

### DIFF
--- a/job_manager.go
+++ b/job_manager.go
@@ -454,7 +454,7 @@ func (jm *JobManager) runDueJobsInner() {
 			if !jm.IsDisabled(jobName) {
 				if nextRunTime.Before(now) {
 					job := jm.getLoadedJob(jobName)
-					jm.nextRunTimes[jobName] = jm.getSchedule(jobName).GetNextRunTime(&now)
+					jm.setNextRunTime(jobName, jm.getSchedule(jobName).GetNextRunTime(&now))
 					jm.setLastRunTime(jobName, now)
 					err = jm.RunTask(job)
 					if err != nil {


### PR DESCRIPTION
Ran into a panic because of a concurrent read and write of nextRunTimes. Looked into it and this line was previously doing a modification of that map without locking it, so there was a race condition.